### PR TITLE
Switch from using Mojang's API to using Ashcon to query data

### DIFF
--- a/src/main/kotlin/io/github/slaxnetwork/routing/profile/ProfileRouting.kt
+++ b/src/main/kotlin/io/github/slaxnetwork/routing/profile/ProfileRouting.kt
@@ -34,12 +34,8 @@ fun Route.profileRouting() {
 
             if(profile == null && call.authorized) {
                 // create.
-                val mojangProfile =
-                    (if(ctx.byUsername) {
-                        MojangUtils.getProfileFromName(ctx.query)
-                    } else {
-                        MojangUtils.getProfileFromUUID(UUID.fromString(ctx.query))
-                    }).getOrThrow()
+                val mojangProfile = MojangUtils.getProfile(ctx.query)
+                    .getOrThrow()
 
                 profile = profileRepository.create(Profile(
                     mojangProfile.uuid,


### PR DESCRIPTION
Mojang's API is rate limited unlike Ashcon's, if Ashcon for whatever reason fails it will default back to using Mojang's API.