### PR TITLE
Lazy Initialization

### DIFF
--- a/src/main/kotlin/io/github/slaxnetwork/utils/Client.kt
+++ b/src/main/kotlin/io/github/slaxnetwork/utils/Client.kt
@@ -2,4 +2,6 @@ package io.github.slaxnetwork.utils
 
 import io.github.slaxnetwork.shared.createHttpClient
 
-internal val client = createHttpClient("kyouko")
+internal val client by lazy {
+    createHttpClient("kyouko")
+}


### PR DESCRIPTION
Using a lazy property to initialize the client variable. This means that the createHttpClient("kyouko") function will not be called until the first time the client variable is accessed. 